### PR TITLE
lint.yml: Adding a linter for doing clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: [push]
+
+jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Install ClangFormat
+        run: sudo apt-get install -y clang-format
+
+      - name: Run linters
+        # Have to use this version until they release a newer version
+        uses: wearerequired/lint-action@640cbd3acbeb113f05067c41db28f1836e1861ce
+
+        with:
+          clang_format: true

--- a/inc/skink/memcpy.h
+++ b/inc/skink/memcpy.h
@@ -24,4 +24,4 @@ inline void *__folly_memcpy(  //
 #endif
 }  // extern "C"
 
-} // namespace sk
+}  // namespace sk

--- a/inc/skink/random.h
+++ b/inc/skink/random.h
@@ -214,4 +214,4 @@ struct xoros256ss : prng_base<xoros256ss> {
 // Expose xoroshiro256** as the default PRNG.
 using prng = xoros256ss;
 
-} // namespace sk
+}  // namespace sk

--- a/inc/skink/sizeptr.h
+++ b/inc/skink/sizeptr.h
@@ -69,4 +69,4 @@ struct sizeptr<T, std::enable_if_t<std::is_void_v<T>>> {
   ssize_t size_;
 };
 
-} // namespace sk
+}  // namespace sk

--- a/inc/skink/spinlock.h
+++ b/inc/skink/spinlock.h
@@ -46,4 +46,4 @@ struct ABSL_LOCKABLE spinlock {
   mutable std::atomic<bool> flag_ = false;
 };
 
-} // namespace sk
+}  // namespace sk

--- a/inc/skink/zstream.h
+++ b/inc/skink/zstream.h
@@ -476,4 +476,4 @@ struct zstream {
       SHARED_LOCKS_REQUIRED(buffer_lock_);
 };
 
-} // namespace sk
+}  // namespace sk

--- a/lib/zstream.cc
+++ b/lib/zstream.cc
@@ -399,4 +399,4 @@ void zstream::inc_reader(int id, int64_t nbytes) {
   reader_scan_lock_.unlock();
 }
 
-} // namespace sk
+}  // namespace sk

--- a/test/random_test.cc
+++ b/test/random_test.cc
@@ -11,7 +11,8 @@ using ::testing::Ge;
 using ::testing::Le;
 using ::testing::Lt;
 
-template <typename T> void TestIntInRange(xoros256ss &prng) {
+template <typename T>
+void TestIntInRange(xoros256ss &prng) {
   EXPECT_THAT(prng.uniform_int<T>(),
               AllOf(Ge(std::numeric_limits<T>::min()),
                     Le(std::numeric_limits<T>::max())));


### PR DESCRIPTION
* This commit provides a new github workflow to do clang formatting on all pushes