### PR TITLE
Back off on minimum required CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 # Prefer clang when present.
 find_program(CMAKE_C_COMPILER NAMES   $ENV{CC}  clang   gcc PATHS ENV PATH NO_DEFAULT_PATH)


### PR DESCRIPTION
Looks like build works just fine with an older version of CMake, patch takes it back at least as far as 3.16 (which is installed with Ubuntu 20.04)